### PR TITLE
- Fix the right lib where zfs_cmd_t structure is declared.

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -2376,7 +2376,7 @@ cdef class ZFSDataset(ZFSObject):
         cdef zfs.zfs_cmd_t cmd
         cdef int ret
 
-        memset(&cmd, 0, cython.sizeof(libzfs.zfs_cmd))
+        memset(&cmd, 0, cython.sizeof(zfs.zfs_cmd_t))
 
         cmd.zc_cookie = fd
         strncpy(cmd.zc_name, self.name, zfs.MAXPATHLEN)

--- a/pxd/zfs.pxd
+++ b/pxd/zfs.pxd
@@ -54,6 +54,7 @@ cdef extern from "sys/fs/zfs.h" nogil:
         ZFS_IMPORT_ANY_HOST
         ZFS_IMPORT_MISSING_LOG
         ZFS_IMPORT_ONLY
+        ZFS_ONLINE_EXPAND
 
     IF (FREEBSD_VERSION >= 1003509 and FREEBSD_VERSION <= 1100000) or FREEBSD_VERSION >= 1100504:
         enum:


### PR DESCRIPTION
- Declare the define ZFS_ONLINE_EXPAND.

Fix the issues related on iocage/iocage#297

Also built it on FreeBSD: 1101001 and 1200030